### PR TITLE
DEV-50713 Configure build to publish to Maven Central

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ RUNNING_PID
 
 # Ignore Gradle build output directory
 build
+
+# Ignore Gradle private values
+gradle.properties

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Curalate, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The recommended way to install the library for Android is with a build system li
 
 ```groovy
 dependencies {
-  implementation 'com.curalate:curalate-android-sdk:0.1.1'
+  implementation 'com.curalate:android-sdk:0.1.2'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,10 @@
 //
 
 plugins {
-    // Apply the java-library plugin to add support for Java Library
+    id 'io.codearte.nexus-staging' version '0.21.1'
     id 'java-library'
+    id 'maven-publish'
+    id 'signing'
 }
 
 repositories {
@@ -29,4 +31,88 @@ dependencies {
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
+}
+
+group   = 'com.curalate'
+version = '0.1.2'
+
+ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
+
+task javadocJar(type: Jar) {
+    from javadoc
+    archiveClassifier = 'javadoc'
+}
+
+task sourcesJar(type: Jar) {
+    from sourceSets.main.allJava
+    archiveClassifier = 'sources'
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = 'android-sdk'
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+
+            versionMapping {
+                usage('java-api') {
+                    fromResolutionOf('runtimeClasspath')
+                }
+                usage('java-runtime') {
+                    fromResolutionResult()
+                }
+            }
+
+            pom {
+                name        = 'Curalate Android SDK'
+                description = "API client to call Curalate's API methods from an Android app (or other project running on the JDK)"
+                url         = 'https://curalate.com'
+
+                licenses {
+                    license {
+                        name = 'The MIT License (MIT)'
+                        url  = 'https://opensource.org/licenses/MIT'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id    = 'curalate_engineering'
+                        name  = 'Curalate Engineering'
+                        email = 'support@curalate.com'
+                    }
+                }
+
+                scm {
+                    connection          = 'scm:git:https://github.com/curalate/curalate-android-sdk'
+                    developerConnection = 'scm:git:https://github.com/curalate/curalate-android-sdk'
+                    url                 = 'https://github.com/curalate/curalate-android-sdk'
+                }
+            }
+        }
+    }
+
+    repositories {
+        // Maven Central
+        maven {
+            def releasesRepoUrl  = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+            url = isReleaseVersion ? releasesRepoUrl : snapshotsRepoUrl
+            credentials {
+                username = nexusUsername
+                password = nexusPassword
+            }
+        }
+    }
+}
+
+signing {
+    sign publishing.publications.mavenJava
+}
+
+nexusStaging {
+    username = nexusUsername
+    password = nexusPassword
 }

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+./gradlew clean assemble publishMavenJavaPublicationToMavenRepository closeAndReleaseRepository


### PR DESCRIPTION
Several updates to get these builds publishing to Central:
* Change artifact name to `android-sdk`
* Add MIT license
* Add `release.sh` script to publish and promote

Note that this is not automated yet.